### PR TITLE
NamedTemporaryFile Support on Windows - #6 Issue

### DIFF
--- a/hardcopy/__init__.py
+++ b/hardcopy/__init__.py
@@ -1,5 +1,6 @@
 import subprocess
-from tempfile import NamedTemporaryFile
+
+from django.core.files.temp import NamedTemporaryFile
 
 from hardcopy.conf import settings
 

--- a/hardcopy/views.py
+++ b/hardcopy/views.py
@@ -1,4 +1,4 @@
-from tempfile import NamedTemporaryFile
+from django.core.files.temp import NamedTemporaryFile
 from django.http import FileResponse
 
 from hardcopy import bytestring_to_pdf, bytestring_to_png


### PR DESCRIPTION
> This is needed because the Python implementation of NamedTemporaryFile uses the
O_TEMPORARY flag under Windows, which prevents the file from being reopened
if the same flag is not provided [1][2]. Note that this does not address the
more general issue of opening a file for writing and reading in multiple
processes in a manner that works across platforms.
The custom version of NamedTemporaryFile doesn't support the same keyword
arguments available in tempfile.NamedTemporaryFile.
1: https://mail.python.org/pipermail/python-list/2005-December/336957.html
2: http://bugs.python.org/issue14243

sauce: https://github.com/django/django/blob/master/django/core/files/temp.py

In response to issue #6 .. It has the potential to cause problems, as not all keyword arguments are supported. However, in our use case it does not appear to cause any problems. Maintainers can decide if they want to merge it.